### PR TITLE
Install different python versions in separate environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ install:
 - export PATH="$CONDA_PREFIX/bin:$PATH"
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
-- conda install python=$TRAVIS_PYTHON_VERSION
+- conda create -n _testing python=$TRAVIS_PYTHON_VERSION
+- source activate _testing
 - conda install scripting -c csdms-stack
 - conda install landlab jupyter -c landlab
 - conda info -a && conda list


### PR DESCRIPTION
Addresses #20.

A synopsis of this issue and solution from @mcflugen in https://github.com/landlab/landlab/pull/633:

> This has to do with a change with conda/Miniconda3 that no longer allows installing a different version of Python into the root environment. To fix this, I changed things so that we create a separate environment (with the appropriate Python version) to run our tests in.

@mcflugen,
- I set the base of this pull request to ```next``` in order to get the new tutorials passing. 
- I may have created a branch, ```new``` by accident. I see this branch in my branches list. Before I delete the ```new``` branch, I wish to verify with you that the ```new``` branch should indeed not be a thing.