### PR TITLE
Remove tests for Python 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 env:
   matrix:
   - TRAVIS_PYTHON_VERSION="2.7"
-  - TRAVIS_PYTHON_VERSION="3.5"
   - TRAVIS_PYTHON_VERSION="3.6"
   global:
     - CONDA_PREFIX=$HOME/miniconda


### PR DESCRIPTION
This pull request just removes the Python 3.5 tests for the tutorials. *conda-forge* no longer supports 3.5 packages and so our latest versions are not available for Python 3.5 - only 2.7 and 3.6. Once we have a Python 3.7 build, we we'll add that to our CI tests.