### PR TITLE
minor edits to grid object demo ttl

### DIFF
--- a/grid_object_demo/grid_object_demo.ipynb
+++ b/grid_object_demo/grid_object_demo.ipynb
@@ -39,16 +39,15 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "from landlab import RasterModelGrid, VoronoiDelaunayGrid, HexModelGrid\n",
+    "\n",
     "smg = RasterModelGrid((3, 4), 1.)  # a square-cell raster, 3 rows x 4 columns, unit spacing\n",
-    "rmg = RasterModelGrid((3, 4), (1., 2.))  # a rectangular-cell raster\n",
-    "hmg = HexModelGrid(3, 4, 1.)\n",
+    "rmg = RasterModelGrid((3, 4), xy_spacing=(1., 2.))  # a rectangular-cell raster\n",
+    "hmg = HexModelGrid(shape=(3, 4), dx=1.)\n",
     "# ^a hexagonal grid with 3 rows, 4 columns from the base row, & node spacing of 1.\n",
     "x = np.random.rand(100) * 100.\n",
     "y = np.random.rand(100) * 100.\n",
@@ -72,15 +71,15 @@
     "\n",
     "## Understanding the topology of Landlab grids\n",
     "\n",
-    "All grids consist of two interlocked sets of *points* joined by *lines* outlining *areas*. If we define data on the points we call **nodes**, then they are joined by **links** which outline **patches**. Each node within the interior of the grid lies at the geometric center of the area of a **cell**. The cell's edges are **faces**, and the point at the edge of each face is a **corner**.\n",
+    "All grids consist of two interlocked sets of *points* joined by *lines* outlining *areas*. If we define data on the points we call **nodes**, then they are joined by **links**, which outline **patches**. Each node within the interior of the grid lies at the geometric center of the area of a **cell**. The cell's edges are **faces**, and the endpoints of the faces---which are also vertices of the cells---are **corners**.\n",
     "\n",
     "Note that this kind of scheme requires one set of features to be \"dominant\" over the other; i.e., either not every node has a cell, *or* not every link is crossed by a face. Both cannot be true, because one or other set of features has to define the edge of the grid. Landlab assumes that the node set is primary, so there are always more nodes than corners; more links than faces; and more patches than cells.\n",
     "\n",
-    "Each of these sets of *\"elements\"* has its own set of IDs. These IDs are what allow us to index the various Landlab fields which store spatial data. Each feature is ordered by **x, then y**. The origin is always at the bottom left node, unless you choose to move it (`grid.move_origin`)... except in the specific case of a radial grid, where logic and symmetry dictates it must be the central node.\n",
+    "Each of these sets of *\"elements\"* has its own set of IDs. These IDs are what allow us to index the various Landlab fields, which store spatial data. Each feature is ordered by **x, then y**. The origin is always at the bottom left node, unless you choose to move it (`grid.move_origin`)... except in the specific case of a radial grid, where logic and symmetry dictates it must be the central node.\n",
     "\n",
     "Whenever Landlab needs to order something rotationally (angles; elements around a different element type), it does so following the standard mathematical convention of **counterclockwise from east**. We'll see this in practical terms a bit later in this tutorial.\n",
     "\n",
-    "The final thing to know is that **lines have direction**. This lets us record fluxes on the grid by associating them with, and mapping them onto, the links (or, much less commonly, the faces). All lines point into the **upper right quadrant**. So, on our raster, this means the horizontal links point east an the vertical links point north.\n",
+    "The final thing to know is that **links and faces have direction**. This lets us record fluxes on the grid by associating them with, and mapping them onto, the links (or, much less commonly, the faces). All lines point into the **upper right half-space**. So, on our raster, this means the horizontal links point east and the vertical links point north.\n",
     "\n",
     "So, for reference, our raster grid looks like this:\n",
     "\n",
@@ -110,17 +109,15 @@
     "\n",
     "## Recording and indexing the values at elements\n",
     "\n",
-    "Landlab lets you record values at any element you want. In practice, the most useful places to store data is on the primary elements of nodes, links, and patches, the the nodes being most useful for scalar values (e.g, elevations) and the links for fluxes with direction to them (e.g., discharges).\n",
+    "Landlab lets you record values at any element you want. In practice, the most useful places to store data is on the primary elements of nodes, links, and patches, with the nodes being most useful for scalar values (e.g, elevations) and the links for fluxes with direction to them (e.g., velocity or discharge).\n",
     "\n",
-    "In order to maintain compatibility across data types, *all* landlab data is stored in *number-of-elements*-long arrays. This includes both user-defined data and the properties of the nodes within the grid. This means that these arrays can be immediately indexed by their element ID. In other words:"
+    "In order to maintain compatibility across data types, *all* landlab data are stored in *number-of-elements*-long arrays. This includes both user-defined data and the properties of the nodes within the grid. This means that these arrays can be immediately indexed by their element ID. For example:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -134,7 +131,7 @@
     }
    ],
    "source": [
-    "# what's the y-coordinates of the pair of nodes in the middle of our 3-by-4 grid?\n",
+    "# what are the y-coordinates of the pair of nodes in the middle of our 3-by-4 grid?\n",
     "# the IDs of these nodes are 5 and 6, so:\n",
     "smg.y_of_node[[5, 6]]"
    ]
@@ -149,9 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -165,7 +160,7 @@
     }
    ],
    "source": [
-    "# what's the x-coordinates of the middle row?\n",
+    "# what are the x-coordinates of nodes in the middle row?\n",
     "smg.x_of_node.reshape(smg.shape)[1, :]"
    ]
   },
@@ -173,15 +168,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This same data storage pattern is what underlies the Landlab **data fields**, which are simply one dimensional, number-of-elements-long arrays which store user defined spatial data across the grid, attached to the grid itself."
+    "This same data storage pattern is what underlies the Landlab **data fields**, which are simply one dimensional, number-of-elements-long arrays that store user defined spatial data across the grid, attached to the grid itself."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -210,9 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -236,20 +227,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Landlab **components** use fields to share spatial information between themselves. See the *fields* and *components* tutorials for more information.\n",
+    "The Landlab **components** use fields to share spatial information among themselves. See the *fields* and *components* tutorials for more information.\n",
     "\n",
     "\n",
     "## Getting this information from the grid object\n",
     "\n",
-    "All of this topological information is recorded within our grid objects, and can be used to work with data that is defined over the grid. The grids record the numbers of each element, their positions, and their interrelationships to each other. Let's take a look at some of this information for the raster:"
+    "All of this topological information is recorded within our grid objects, and can be used to work with data arrays that are defined over the grid. The grid records the numbers of each element, their positions, and their relationships with one another. Let's take a look at some of this information for the raster:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -269,9 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -298,26 +285,24 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(0, 0.0, 0.0)\n",
-      "(1, 1.0, 0.0)\n",
-      "(2, 2.0, 0.0)\n",
-      "(3, 3.0, 0.0)\n",
-      "(4, 0.0, 1.0)\n",
-      "(5, 1.0, 1.0)\n",
-      "(6, 2.0, 1.0)\n",
-      "(7, 3.0, 1.0)\n",
-      "(8, 0.0, 2.0)\n",
-      "(9, 1.0, 2.0)\n",
-      "(10, 2.0, 2.0)\n",
-      "(11, 3.0, 2.0)\n"
+      "0 0.0 0.0\n",
+      "1 1.0 0.0\n",
+      "2 2.0 0.0\n",
+      "3 3.0 0.0\n",
+      "4 0.0 1.0\n",
+      "5 1.0 1.0\n",
+      "6 2.0 1.0\n",
+      "7 3.0 1.0\n",
+      "8 0.0 2.0\n",
+      "9 1.0 2.0\n",
+      "10 2.0 2.0\n",
+      "11 3.0 2.0\n"
      ]
     }
    ],
@@ -336,9 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -375,15 +358,17 @@
    "source": [
     "Boundary conditions are likewise defined on these elements (see also the full boundary conditions tutorial). Landlab is clever enough to ensure that the boundary conditions recorded on, say, the links get updated when you redefine the conditions on, say, the nodes.\n",
     "\n",
-    "Nodes can be *core*, *fixed value*, *fixed gradient*, or *closed* (flux into or out of node is forbidden). Links can be *active* (can carry flux), *fixed* (always  carries the same flux; joined to a fixed gradient node) or *inactive* (forbidden from carrying flux). This information is likewise available from the grid:"
+    "Nodes can be *core*, *fixed value*, *fixed gradient*, or *closed* (flux into or out of node is forbidden). Links can be *active* (can carry flux), *fixed* (always  carries the same flux; joined to a fixed gradient node) or *inactive* (forbidden from carrying flux). \n",
+    "\n",
+    "Note that this boundary coding does not mean that a particular boundary condition is automatically enforced. It's up to the user to take advantage of these codes. For example, if you are writing a model that calculates flow velocity on links but wish the velocity to be zero at inactive links, you the programmer must ensure this, for instance by including a line like `my_velocity[grid.inactive_links] = 0.0`, or alternatively `my_velocity[grid.active_links] = ...<something>...`.\n",
+    "\n",
+    "Information on boundary coding is available from the grid:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -403,9 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -425,9 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -455,7 +436,7 @@
     "\n",
     "Importantly, we can also find out which elements are connected to which other elements. This allows us to do computationally vital operations involving mapping values defined at one element onto another, e.g., the net flux at a node; the mean slope at a patch; the node value at a cell.\n",
     "\n",
-    "In cases where these relationships are one-to-many (e.g., `links_at_node`, `nodes_at_patch`), the shape of the resulting arrays is always (number_of_elements, max-number-of-connected-elements-across-grid). i.e., on a raster, `links_at_node` is (nnodes, 4), because the cells are always square. On an irregular Voronoi-cell grid, `links_at_node` will be (nnodes, X) where X is the number of sides of the side-iest cell, and `nodes_at_patch` will be (npatches, 3) because all the patches are Delaunay triangles. And so on.\n",
+    "In cases where these relationships are one-to-many (e.g., `links_at_node`, `nodes_at_patch`), the shape of the resulting arrays is always (number_of_elements, max-number-of-connected-elements-across-grid). For example, on a raster, `links_at_node` is (nnodes, 4), because the cells are always square. On an irregular Voronoi-cell grid, `links_at_node` will be (nnodes, X) where X is the number of sides of the side-iest cell, and `nodes_at_patch` will be (npatches, 3) because all the patches are Delaunay triangles. And so on.\n",
     "\n",
     "Lets take a look. Remember, Landlab orders things **clockwise from east**, so for a raster the order will the EAST, NORTH, WEST, SOUTH."
    ]
@@ -463,9 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -485,9 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -514,9 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -536,9 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -569,9 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -603,9 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -625,9 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -648,15 +615,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A bit of thought reveals that things get a bit more complicated for links and faces, because they have direction. You'll need a convenient way to record whether a given flux (which is positive if it goes with the link's inherent direction, and negative if against) actually is travelling into or out of a given node. The grid provides `link_dirs_at_node` and `active_link_dirs_at_node` to help with this:"
+    "A bit of thought reveals that things get more complicated for links and faces, because they have direction. You'll need a convenient way to record whether a given flux (which is positive if it goes with the link's inherent direction, and negative if against) actually is travelling into or out of a given node. The grid provides `link_dirs_at_node` and `active_link_dirs_at_node` to help with this:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -687,9 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -710,9 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -750,9 +711,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -765,7 +724,7 @@
    "source": [
     "fluxes_at_node = smg.at_link['slope'][smg.links_at_node]\n",
     "# ^...remember we defined the slope field as ones, above\n",
-    "fluxes_into_node = fluxes_at_node*smg.active_link_dirs_at_node\n",
+    "fluxes_into_node = fluxes_at_node * smg.active_link_dirs_at_node\n",
     "flux_div_at_node = fluxes_into_node.sum(axis=1)\n",
     "print(flux_div_at_node[smg.core_nodes])"
    ]
@@ -776,7 +735,7 @@
    "source": [
     "Why? Remember that earlier in this tutorial we already set the bottom edge to `CLOSED_BOUNDARY`. So each of our core nodes has a flux of +1.0 coming in from the left, but two fluxes of -1.0 leaving from both the top and the right. Hence, the flux divergence is -1. at each node.\n",
     "\n",
-    "Note as well that Landlab offers the one-line grid method `calc_flux_div_at_node()` to perform this same operation."
+    "Note as well that Landlab offers the one-line grid method `calc_flux_div_at_node()` to perform this same operation. For more on this, see the **gradient_and_divergence** tutorial."
    ]
   },
   {
@@ -789,23 +748,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Minor editing on grid-object-demo tutorial. Includes using shape and dx keyword arguments for hex grid initialization, in anticipation of LL 2.0.